### PR TITLE
Support node 12.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { readFile, writeFile } = require('fs/promises')
+const { readFile, writeFile } = require('fs').promises
 
 const imagemin = require('imagemin')
 


### PR DESCRIPTION
I really want to use this package, but it is incompatible with Node 12.x. The reason is that Node 12.x doesn't support `require('fs/promises')` and would have you instead use `require('fs').promises` ([StackOverflow](https://stackoverflow.com/questions/64725249/fs-promises-api-in-typescript-not-compiling-in-javascript-correctly)).

<img width="385" alt="Screen Shot 2021-04-09 at 11 49 54 AM" src="https://user-images.githubusercontent.com/4816472/114227330-b556b700-9929-11eb-8f0e-cfb87ae14252.png">

Tested this fix with Node 12.18.3 and it works! 